### PR TITLE
Fix #1 by setting selection on footnote

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -65,7 +65,7 @@ const Example = React.createClass({
         const { state } = this.state;
 
         this.onChange(
-            footnotePlugin.transforms.insertFootnote(state.transform()).apply()
+            footnotePlugin.transforms.insertFootnote(state.transform()).focus().apply()
         );
     },
 

--- a/src/insertFootnote.js
+++ b/src/insertFootnote.js
@@ -20,7 +20,7 @@ function insertFootnote(opts, transform, defaultText = DEFAULT_TEXT) {
 
     const { document } = state;
     const lastIndex = document.nodes.count();
-    let footnote = Slate.Block.create({
+    const footnote = Slate.Block.create({
         type: opts.typeFootnote,
         data: { id: footnodeRef },
         nodes: [Slate.Text.create()]
@@ -44,7 +44,10 @@ function insertFootnote(opts, transform, defaultText = DEFAULT_TEXT) {
 
         // Insert text
         .moveToRangeOf(footnote)
-        .insertText(defaultText);
+        .insertText(defaultText)
+        // set selection to footnote
+        .focus()
+        .extendBackward(defaultText.length);
 
     return transform;
 }

--- a/src/insertFootnote.js
+++ b/src/insertFootnote.js
@@ -46,7 +46,6 @@ function insertFootnote(opts, transform, defaultText = DEFAULT_TEXT) {
         .moveToRangeOf(footnote)
         .insertText(defaultText)
         // set selection to footnote
-        .focus()
         .extendBackward(defaultText.length);
 
     return transform;

--- a/tests/selection/expected.yaml
+++ b/tests/selection/expected.yaml
@@ -1,0 +1,20 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "Hello World"
+      - kind: inline
+        isVoid: true
+        type: footnote_ref
+        data:
+          id: "1"
+      - kind: text
+        text: ""
+  - kind: block
+    type: footnote
+    data:
+      id: "1"
+    nodes:
+      - kind: text
+        text: Enter footnote here.

--- a/tests/selection/input.yaml
+++ b/tests/selection/input.yaml
@@ -1,0 +1,8 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        # move selection here
+        key: _cursor_
+        text: "Hello World"

--- a/tests/selection/transform.js
+++ b/tests/selection/transform.js
@@ -12,7 +12,6 @@ module.exports = function(plugin, state) {
     const selection = state.selection;
     expect(selection.startOffset).toEqual(0);
     expect(selection.endOffset).toEqual(20);
-    expect(selection.isFocused).toEqual(true);
 
     return state;
 };

--- a/tests/selection/transform.js
+++ b/tests/selection/transform.js
@@ -1,0 +1,18 @@
+const expect = require('expect');
+
+module.exports = function(plugin, state) {
+    const cursorBlock = state.document.getDescendant('_cursor_');
+
+    state = state.transform()
+        .moveToRangeOf(cursorBlock)
+        .apply();
+
+    state = plugin.transforms.insertFootnote(state.transform()).apply();
+
+    const selection = state.selection;
+    expect(selection.startOffset).toEqual(0);
+    expect(selection.endOffset).toEqual(20);
+    expect(selection.isFocused).toEqual(true);
+
+    return state;
+};


### PR DESCRIPTION
Should fix #1 

This PR introduces a little change to the transform to extendBackward with the default text length. It also sets focus on the element.

Also introduce some tests to assert selection startOffset and endOffset are 0->20