### PR TITLE
Apply transform to split block on enter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+const Slate = require('slate');
 const makeSchema = require('./makeSchema');
 const insertFootnote = require('./insertFootnote');
 const isSelectionInFootnote = require('./utils/isSelectionInFootnote');
@@ -29,17 +30,22 @@ function EditFootnote(opts = {}) {
                 event.stopPropagation();
                 event.preventDefault();
 
-                const transform = state.transform();
+                const { document } = state;
 
-                return transform
-                    .collapseToEndOf(state.startBlock)
-                    .splitBlock()
-                    .setBlock({ type: opts.defaultBlock, data: {} })
-                    .moveNodeByKey(
-                        transform.state.document.getPreviousBlock(transform.state.startBlock.key),
-                        transform.state.document.key,
-                        transform.state.document.nodes.size
-                    )
+                // Find first footnote index for a footnote in the document
+                const firstFootnoteIndex = document.nodes.findKey((node) => {
+                    return node.type === opts.typeFootnote;
+                });
+
+                // Create an empty block of type defaultBlock
+                const block = Slate.Block.create({
+                    type: opts.defaultBlock,
+                    data: {}
+                });
+
+                return state.transform()
+                    .insertNodeByKey(document.key, firstFootnoteIndex, block)
+                    .moveToRangeOf(block)
                     .apply();
             }
         }

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const isSelectionInFootnote = require('./utils/isSelectionInFootnote');
 function EditFootnote(opts = {}) {
     opts.typeFootnote = opts.typeFootnote || 'footnote';
     opts.typeRef = opts.typeRef || 'footnote_ref';
+    opts.defaultBlock = opts.defaultBlock || 'paragraph';
 
     const schema = makeSchema(opts);
 
@@ -27,7 +28,19 @@ function EditFootnote(opts = {}) {
             if (data.key === 'enter' && isSelectionInFootnote(opts, state)) {
                 event.stopPropagation();
                 event.preventDefault();
-                return state;
+
+                const transform = state.transform();
+
+                return transform
+                    .collapseToEndOf(state.startBlock)
+                    .splitBlock()
+                    .setBlock({ type: opts.defaultBlock, data: {} })
+                    .moveNodeByKey(
+                        transform.state.document.getPreviousBlock(transform.state.startBlock.key),
+                        transform.state.document.key,
+                        transform.state.document.nodes.size
+                    )
+                    .apply();
             }
         }
     };

--- a/tests/enter-split-block/expected.yaml
+++ b/tests/enter-split-block/expected.yaml
@@ -1,0 +1,25 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "Hello World"
+      - kind: inline
+        isVoid: true
+        type: footnote_ref
+        data:
+          id: "1"
+      - kind: text
+        text: ""
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: ""
+  - kind: block
+    type: footnote
+    data:
+      id: "1"
+    nodes:
+      - kind: text
+        text: Enter footnote here.

--- a/tests/enter-split-block/expected.yaml
+++ b/tests/enter-split-block/expected.yaml
@@ -3,12 +3,19 @@ nodes:
     type: paragraph
     nodes:
       - kind: text
-        text: "Hello World"
+        text: "Hello "
       - kind: inline
         isVoid: true
         type: footnote_ref
         data:
           id: "1"
+      - kind: text
+        text: "World"
+      - kind: inline
+        isVoid: true
+        type: footnote_ref
+        data:
+          id: "2"
       - kind: text
         text: ""
   - kind: block
@@ -20,6 +27,13 @@ nodes:
     type: footnote
     data:
       id: "1"
+    nodes:
+      - kind: text
+        text: Enter footnote here.
+  - kind: block
+    type: footnote
+    data:
+      id: "2"
     nodes:
       - kind: text
         text: Enter footnote here.

--- a/tests/enter-split-block/input.yaml
+++ b/tests/enter-split-block/input.yaml
@@ -3,14 +3,19 @@ nodes:
     type: paragraph
     nodes:
       - kind: text
-        text: "Hello World"
+        text: "Hello "
       - kind: inline
         isVoid: true
         type: footnote_ref
         data:
           id: "1"
       - kind: text
-        text: ""
+        text: "World"
+      - kind: inline
+        isVoid: true
+        type: footnote_ref
+        data:
+          id: "2"
   - kind: block
     type: footnote
     data:
@@ -19,4 +24,11 @@ nodes:
       - kind: text
         # move selection here
         key: _cursor_
+        text: Enter footnote here.
+  - kind: block
+    type: footnote
+    data:
+      id: "2"
+    nodes:
+      - kind: text
         text: Enter footnote here.

--- a/tests/enter-split-block/input.yaml
+++ b/tests/enter-split-block/input.yaml
@@ -1,0 +1,22 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: "Hello World"
+      - kind: inline
+        isVoid: true
+        type: footnote_ref
+        data:
+          id: "1"
+      - kind: text
+        text: ""
+  - kind: block
+    type: footnote
+    data:
+      id: "1"
+    nodes:
+      - kind: text
+        # move selection here
+        key: _cursor_
+        text: Enter footnote here.

--- a/tests/enter-split-block/transform.js
+++ b/tests/enter-split-block/transform.js
@@ -1,0 +1,14 @@
+module.exports = function(plugin, state) {
+    const cursorBlock = state.document.getDescendant('_cursor_');
+
+    state = state.transform()
+        .moveToRangeOf(cursorBlock)
+        .apply();
+
+    return plugin.onKeyDown({
+        stopPropagation: () => {},
+        preventDefault: () => {}
+    }, {
+        key: 'enter'
+    }, state);
+};


### PR DESCRIPTION
This PR introduces a slight change to enter behaviour, where we apply a transform to split the block into a paragraph and have it inserted right before the footnote, at the end of the document.